### PR TITLE
Improve run_server onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This directory is the FS_ROOT exposed by your MCP server. It includes a minimal 
 - notes/ — scratchpad
 
 ## Quick start (server)
+Prerequisites:
+
+- Python 3.9+ with the `venv` module available (on Debian/Ubuntu install via `apt install python3 python3-venv`).
+
+The helper script will reuse the active virtualenv if you already have one selected. Otherwise it will create `.venv/` in the repo root on first run and install the server requirements automatically.
+
 Run from the host (outside the jail):
 
 ```bash


### PR DESCRIPTION
## Summary
- document the prerequisites for running the helper server script and explain the automatic virtualenv handling
- make `run_server.sh` detect/create the correct Python environment with clearer errors and reuse an already-active venv when possible
- install dependencies via `requirements.txt` when available and report a friendlier Uvicorn status message

## Testing
- ./mcp-fs/run_server.sh --restart --foreground

------
https://chatgpt.com/codex/tasks/task_e_68cdd54080b083239ac6f98bb8ffb888