### PR TITLE
Clarify port exposure requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prerequisites:
 
 The helper script will reuse the active virtualenv if you already have one selected. Otherwise it will create `.venv/` in the repo root on first run and install the server requirements automatically.
 
-Run from the host (outside the jail):
+Run from the host (outside the jail). Ensure port 8000 is exposed in the environment where the server runs so the proxy URL above can reach it. Then run:
 
 ```bash
 # from the repo root (defaults auto-detect this checkout)


### PR DESCRIPTION
## Summary
- clarify in the README that port 8000 must be exposed when running the server

## Testing
- no tests were run (not needed for docs)


------
https://chatgpt.com/codex/tasks/task_e_68cdd7c195688323aaa983651ee9f439