### PR TITLE
Add background job tools and install BAGEL deps

### DIFF
--- a/mcp-fs/run_server.sh
+++ b/mcp-fs/run_server.sh
@@ -125,6 +125,7 @@ make_venv() {
     else
       "$VENV/bin/python" -m pip install -U "mcp[cli]" "uvicorn>=0.30" "starlette>=0.38" >/dev/null
     fi
+    "$VENV/bin/python" -m pip install -r "$REPO_ROOT/projects/BAGEL/requirements.txt" >/dev/null 2>&1 || true
   fi
 
   local uvicorn_version="not installed"


### PR DESCRIPTION
## Summary
- add background job management utilities (start, status, logs, list, stop) to the MCP server to prevent long-call timeouts
- update the run tool to reuse the shared command allowlist helper
- install BAGEL project requirements automatically when provisioning the server environment

## Testing
- python -m compileall mcp-fs/server.py

------
https://chatgpt.com/codex/tasks/task_e_68cdf64028cc83239e7ea0956cc1b795