### PR TITLE
Remove run tool in favor of job execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ Run from the host (outside the jail). Ensure port 8000 is exposed in the environ
   --enable-write --enable-exec --foreground
 ```
 
-## Smoke test (inside MCP via run tool)
-- Exec check: run `bash -lc "echo OK"`
-- Bridge check: `bash -lc "mcp-bridge/ops.sh self-test"`
+The `--enable-exec` flag enables the job tools that launch commands inside the jail.
+
+## Smoke test (inside MCP via job tools)
+- Exec check: call `job_start` with `cmd=["bash", "-lc", "echo OK"]` and confirm output via `job_logs`.
+- Bridge check: start `job_start` with `cmd=["bash", "-lc", "mcp-bridge/ops.sh self-test"]`.
 
 ## Notes
-- Exec allow-list can be extended via env: `MCP_EXEC_ALLOW="bash sh python python3 pip uv pytest git nvidia-smi ls cat head tail ops.sh"`.
-- If your client hides Exec until a tool is marked destructive, annotate `run` and `write_file` in server.py with `destructiveHint` (and `openWorldHint` for run).
+- Exec allow-list for job execution can be extended via env: `MCP_EXEC_ALLOW="bash sh python python3 pip uv pytest git nvidia-smi ls cat head tail ops.sh"`.
+- If your client hides Exec until a tool is marked destructive, annotate `job_start` and `write_file` in server.py with `destructiveHint` (and `openWorldHint` for job_start).
 - `job_start` accepts an optional `timeout_s` to auto-stop runaway processes, and `job_logs` understands `tail_lines`/negative `offset` plus `squash_repeats` to make tailing easier.
 - Use the new `gpu_info` tool to return a lightweight summary from `nvidia-smi` (when available).

--- a/mcp-fs/run_server.sh
+++ b/mcp-fs/run_server.sh
@@ -22,7 +22,7 @@ PORT="${PORT:-8000}"
 FS_ROOT="${FS_ROOT:-$REPO_ROOT/hello-mcp}"   # change to your repo root if you like
 PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-}"       # e.g. https://<POD_ID>-8000.proxy.runpod.net
 MCP_ENABLE_WRITE="${MCP_ENABLE_WRITE:-0}"    # set 1 to allow write_file
-MCP_ENABLE_EXEC="${MCP_ENABLE_EXEC:-0}"      # set 1 to allow run
+MCP_ENABLE_EXEC="${MCP_ENABLE_EXEC:-0}"      # set 1 to allow job tools (job_start, etc.)
 LOG="${LOG:-$APP_DIR/server.log}"
 PIDFILE="${PIDFILE:-$APP_DIR/server.pid}"
 PYTHON_CMD="${PYTHON_CMD:-}"
@@ -42,7 +42,7 @@ Options:
   --host IP               Host to bind (default: $HOST)
   --public-url URL        Public base URL (adds clickable links in fetch())
   --enable-write          Enable write_file tool (default off)
-  --enable-exec           Enable run tool (default off)
+  --enable-exec           Enable job tools (default off)
   --no-update             Skip pip install/upgrade
   --server PATH           Path to server.py (default: $SERVER)
   --foreground            Run in foreground (logs to stdout)
@@ -205,7 +205,7 @@ print_summary() {
   echo "FS_ROOT          : $FS_ROOT"
   echo "Host/Port        : $HOST:$PORT"
   echo "Write enabled    : $MCP_ENABLE_WRITE"
-  echo "Exec enabled     : $MCP_ENABLE_EXEC"
+  echo "Exec enabled     : $MCP_ENABLE_EXEC (job tools)"
   [[ -n "$PUBLIC_BASE_URL" ]] && echo "Public base URL   : $PUBLIC_BASE_URL"
   echo
   echo "Proxy URL (RunPod): https://<POD_ID>-$PORT.proxy.runpod.net"


### PR DESCRIPTION
## Summary
- remove the standalone run MCP tool and enforce job_start as the only execution entry point
- document the job tool workflow in the README and launcher script, including updated exec flag messaging

## Testing
- python -m compileall mcp-fs/server.py

------
https://chatgpt.com/codex/tasks/task_e_68ced42754e8832386adfb106a345d42