### PR TITLE
Include AGENTS.md contents in init response

### DIFF
--- a/mcp-fs/server.py
+++ b/mcp-fs/server.py
@@ -190,6 +190,30 @@ def _trash_root_path() -> Path:
     return _resolve_path(TRASH_ROOT_REL)
 
 
+def _gather_agents_docs() -> List[Dict[str, str]]:
+    """Collect AGENTS.md files under FS_ROOT and return their contents."""
+
+    try:
+        candidates = sorted(FS_ROOT.rglob("AGENTS.md"))
+    except Exception:
+        return []
+
+    docs: List[Dict[str, str]] = []
+    for path in candidates:
+        if not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            continue
+        try:
+            rel = str(path.relative_to(FS_ROOT))
+        except ValueError:
+            rel = str(path)
+        docs.append({"path": rel, "content": content})
+    return docs
+
+
 @mcp.tool()
 def init(mode: str = "quick", include: Optional[Sequence[str]] = None) -> Dict[str, Any]:
     """Initialize the session and surface orientation info.
@@ -280,6 +304,7 @@ def init(mode: str = "quick", include: Optional[Sequence[str]] = None) -> Dict[s
             "log_sink_env": "MCP_LOG_SINK",
         },
         "templates": formatted_templates,
+        "agents": _gather_agents_docs(),
     }
 
 # ------------------------------- FS tooling ---------------------------------

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -62,3 +62,22 @@ def test_jsonl_append_atomic(fs_root):
     assert len(lines) == 2
     assert json.loads(lines[0]) == record_a
     assert json.loads(lines[1]) == record_b
+
+
+def test_init_includes_agents_docs(fs_root):
+    root_agents = fs_root / "AGENTS.md"
+    nested_agents = fs_root / "nested" / "AGENTS.md"
+
+    root_agents.write_text("root instructions")
+    nested_agents.parent.mkdir(parents=True, exist_ok=True)
+    nested_agents.write_text("nested instructions")
+
+    result = server.init()
+
+    assert "agents" in result
+    assert {"path": "AGENTS.md", "content": "root instructions"} in result["agents"]
+
+    assert any(
+        entry["path"] == "nested/AGENTS.md" and entry["content"] == "nested instructions"
+        for entry in result["agents"]
+    )


### PR DESCRIPTION
## Summary
- add a helper to collect AGENTS.md documents under the FS root
- include the gathered documents in the `init` tool output so instructions are always surfaced
- cover the behavior with a regression test for nested AGENTS.md files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf6300a6ec832383bf0c3e4b711717