### PR TITLE
Improve server bootstrap python detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This directory is the FS_ROOT exposed by your MCP server. It includes a minimal 
 ## Quick start (server)
 Prerequisites:
 
-- Python 3.9+ with the `venv` module available (on Debian/Ubuntu install via `apt install python3 python3-venv`).
+- Python 3.10+ with the `venv` module available (on Debian/Ubuntu install via `apt install python3.10 python3.10-venv`).
 
-The helper script will reuse the active virtualenv if you already have one selected. Otherwise it will create `.venv/` in the repo root on first run and install the server requirements automatically.
+The helper script will reuse the active virtualenv if you already have one selected. Otherwise it will create `.venv/` in the repo root on first run and install the server requirements automatically. When multiple interpreters are installed, the script automatically prefers the newest Python ≥3.10 (e.g. `python3.12`, then `python3.11`, etc.). If only an older interpreter is present, the script exits early with guidance so you can install a compatible Python before retrying.
 
 Run from the host (outside the jail). Ensure port 8000 is exposed in the environment where the server runs so the proxy URL above can reach it. Then run:
 

--- a/hello-mcp/notes/2025-09-21-worklog.md
+++ b/hello-mcp/notes/2025-09-21-worklog.md
@@ -1,1 +1,3 @@
 2025-09-21T16:04:00Z — Removed the unstable `search` MCP tool to prevent server crashes when agents invoke it. Updated the filesystem server, docs, and tests to reflect the removal.
+
+2025-09-22T20:08:00Z — Debugged the bootstrap failure caused by Python <3.10 when installing the `mcp` dependency. Updated `run_server.sh` to pick the newest interpreter ≥3.10 (or exit with guidance) and refreshed the README prerequisites so new installs proceed cleanly.

--- a/mcp-fs/run_server.sh
+++ b/mcp-fs/run_server.sh
@@ -82,19 +82,57 @@ ensure_dirs() {
   [[ -f "$SERVER" ]] || die "server.py not found at: $SERVER"
 }
 
+MIN_PY_MAJOR=3
+MIN_PY_MINOR=10
+
+_python_version_string() {
+  local cmd="$1"
+  "$cmd" -c 'import sys; print(".".join(str(p) for p in sys.version_info[:3]))'
+}
+
+_python_meets_min_version() {
+  local cmd="$1"
+  "$cmd" -c "import sys; sys.exit(0 if sys.version_info >= (${MIN_PY_MAJOR}, ${MIN_PY_MINOR}) else 1)"
+}
+
 resolve_python() {
+  local candidate
+  local first_old_cmd=""
+  local first_old_version=""
+
   if [[ -n "${PYTHON_CMD:-}" ]]; then
+    if ! command -v "$PYTHON_CMD" >/dev/null 2>&1; then
+      die "Specified PYTHON_CMD not found: $PYTHON_CMD"
+    fi
+    if ! _python_meets_min_version "$PYTHON_CMD" >/dev/null 2>&1; then
+      local version
+      version="$(_python_version_string "$PYTHON_CMD" 2>/dev/null || true)"
+      [[ -n "$version" ]] || version="unknown"
+      die "Python at $PYTHON_CMD is version $version but the MCP server requires >= ${MIN_PY_MAJOR}.${MIN_PY_MINOR}."
+    fi
     return 0
   fi
-  if command -v python3 >/dev/null 2>&1; then
-    PYTHON_CMD="python3"
-    return 0
+
+  for candidate in python3.12 python3.11 python3.10 python3 python; do
+    if ! command -v "$candidate" >/dev/null 2>&1; then
+      continue
+    fi
+    if _python_meets_min_version "$candidate" >/dev/null 2>&1; then
+      PYTHON_CMD="$candidate"
+      return 0
+    fi
+    if [[ -z "$first_old_cmd" ]]; then
+      first_old_cmd="$candidate"
+      first_old_version="$(_python_version_string "$candidate" 2>/dev/null || true)"
+      [[ -n "$first_old_version" ]] || first_old_version="unknown"
+    fi
+  done
+
+  if [[ -n "$first_old_cmd" ]]; then
+    die "Found Python $first_old_version at $first_old_cmd, but the MCP server requires >= ${MIN_PY_MAJOR}.${MIN_PY_MINOR}. Install a newer Python or set PYTHON_CMD."
   fi
-  if command -v python >/dev/null 2>&1; then
-    PYTHON_CMD="python"
-    return 0
-  fi
-  die "python3 not found. Install Python 3.9+ and rerun."
+
+  die "python ${MIN_PY_MAJOR}.${MIN_PY_MINOR}+ not found. Install Python ${MIN_PY_MAJOR}.${MIN_PY_MINOR}+ (for example via pyenv) and rerun."
 }
 
 make_venv() {
@@ -116,6 +154,13 @@ make_venv() {
 
   # shellcheck disable=SC1090
   source "$activate"
+
+  if ! _python_meets_min_version "$VENV/bin/python" >/dev/null 2>&1; then
+    local current_version
+    current_version="$(_python_version_string "$VENV/bin/python" 2>/dev/null || true)"
+    [[ -n "$current_version" ]] || current_version="unknown"
+    die "Virtualenv Python $current_version is too old; delete $VENV and rerun this script with Python ${MIN_PY_MAJOR}.${MIN_PY_MINOR}+ available."
+  fi
 
   if (( UPDATE_DEPS )); then
     info "Installing/Updating Python deps…"


### PR DESCRIPTION
## Summary
- ensure `run_server.sh` selects the newest Python ≥3.10 and surfaces clear guidance when only older interpreters are present
- fail fast if an existing virtualenv uses an unsupported Python and update the quick-start docs to call out the 3.10+ requirement
- log the onboarding fix in the shared notes

## Testing
- `pytest`
- `./mcp-fs/run_server.sh --no-update --foreground`


------
https://chatgpt.com/codex/tasks/task_e_68d1ab47a08c8323ae536bf1a54b3cdd